### PR TITLE
Refactored Deserializer inner workings to fix Serde compatibility

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -5,7 +5,6 @@ use std::str;
 use num_traits::cast::ToPrimitive;
 
 use serde::de::{self, DeserializeOwned, Visitor};
-use serde::private::de::size_hint;
 
 use crate::error::{Error, Result};
 
@@ -602,6 +601,22 @@ impl<'de> de::VariantAccess<'de> for VariantDeserializer {
                 de::Deserializer::deserialize_any(SeqDeserializer::new(v.elements), visitor)
             }
             _ => Err(Error::ExpectedMap),
+        }
+    }
+}
+
+mod size_hint {
+    pub fn from_bounds<I>(iter: &I) -> Option<usize>
+    where
+        I: Iterator,
+    {
+        helper(iter.size_hint())
+    }
+
+    fn helper(bounds: (usize, Option<usize>)) -> Option<usize> {
+        match bounds {
+            (lower, Some(upper)) if lower == upper => Some(upper),
+            _ => None,
         }
     }
 }

--- a/src/de.rs
+++ b/src/de.rs
@@ -1,47 +1,38 @@
 use eetf::Term;
 use std::io::{self, Read};
-use std::iter;
 use std::str;
 
-use heck::CamelCase;
+use num_traits::cast::ToPrimitive;
 
-use num_traits::cast::{FromPrimitive, ToPrimitive};
-
-use serde::de::{
-    self, DeserializeOwned, DeserializeSeed, EnumAccess, IntoDeserializer, MapAccess, SeqAccess,
-    VariantAccess, Visitor,
-};
+use serde::de::{self, DeserializeOwned, Visitor};
+use serde::private::de::size_hint;
 
 use crate::error::{Error, Result};
-
-use self::private::*;
 
 /// Deserializes an `eetf::Term`
 ///
 /// Generally you should use the from_bytes or from_reader functions instead.
-pub struct Deserializer<'a> {
-    term: &'a Term,
+pub struct Deserializer {
+    term: Term,
 }
 
-impl<'a> Deserializer<'a> {
-    pub fn from_term(term: &'a Term) -> Self {
+impl Deserializer {
+    pub fn new(term: Term) -> Self {
         Deserializer { term }
     }
 }
 
-trait IntoEetfDeserializer {
-    fn into_deserializer(&self) -> Deserializer;
-}
+impl<'de> de::IntoDeserializer<'de, Error> for Deserializer {
+    type Deserializer = Self;
 
-impl IntoEetfDeserializer for Term {
-    fn into_deserializer(&self) -> Deserializer {
-        Deserializer::from_term(self)
+    fn into_deserializer(self) -> Self {
+        self
     }
 }
 
-// impl<'de, 'a: 'de> From<&'a Term> for Deserializer<'de> {
-//     fn from(term: &'a Term) -> Self {
-//         Deserializer::from_term(term)
+// impl From<Term> for Deserializer {
+//     fn from(term: Term) -> Self {
+//         Deserializer::new(term)
 //     }
 // }
 
@@ -52,8 +43,8 @@ where
     T: DeserializeOwned,
 {
     let term = Term::decode(reader)?;
-    let deserializer = Deserializer::from_term(&term);
-    let t = T::deserialize(deserializer)?;
+    let deserializer = Deserializer::new(term);
+    let t = de::Deserialize::deserialize(deserializer)?;
     Ok(t)
 }
 
@@ -68,75 +59,61 @@ where
 }
 
 // Implementation methods for deserializer that require a lifetime.
-impl<'a> Deserializer<'a> {
-    fn parse_integer<T>(&self) -> Result<T>
+impl Deserializer {
+    fn deserialize_integer<'de, V>(self, visitor: V) -> Result<V::Value>
     where
-        T: FromPrimitive,
+        V: Visitor<'de>,
     {
         match self.term {
-            Term::FixInteger(fix_int) => {
-                if let Some(num) = T::from_i32(fix_int.value) {
-                    Ok(num)
-                } else {
-                    Err(Error::IntegerConvertError)
-                }
-            }
-            Term::BigInteger(big_int) => {
-                if let Some(num) = big_int.to_i64() {
-                    if let Some(num) = T::from_i64(num) {
-                        Ok(num)
-                    } else {
-                        Err(Error::IntegerConvertError)
-                    }
-                } else {
-                    Err(Error::IntegerConvertError)
-                }
-            }
+            Term::FixInteger(v) => visitor.visit_i32(v.value),
+            Term::BigInteger(v) => visitor.visit_i64(v.to_i64().ok_or(Error::IntegerConvertError)?),
             _ => Err(Error::ExpectedFixInteger),
-        }
-    }
-
-    fn parse_float<T>(&self) -> Result<T>
-    where
-        T: FromPrimitive,
-    {
-        match self.term {
-            Term::Float(float) => {
-                if let Some(num) = T::from_f64(float.value) {
-                    Ok(num)
-                } else {
-                    Err(Error::IntegerConvertError)
-                }
-            }
-            _ => Err(Error::ExpectedFloat),
-        }
-    }
-
-    fn parse_binary(&self) -> Result<&[u8]> {
-        match self.term {
-            Term::Binary(binary) => Ok(&binary.bytes),
-            _ => Err(Error::ExpectedBinary),
-        }
-    }
-
-    fn parse_string(&self) -> Result<String> {
-        match self.parse_binary() {
-            Ok(bytes) => str::from_utf8(&bytes)
-                .map(|s| s.to_string())
-                .or(Err(Error::Utf8DecodeError)),
-            Err(e) => Err(e),
         }
     }
 }
 
-impl<'de, 'a: 'de> de::Deserializer<'de> for Deserializer<'a> {
+fn visit_term_seq<'de, V>(term: Vec<Term>, visitor: V) -> Result<V::Value>
+where
+    V: Visitor<'de>,
+{
+    let mut deserializer = SeqDeserializer::new(term);
+    let value = visitor.visit_seq(&mut deserializer)?;
+    Ok(value)
+}
+
+fn visit_term_map<'de, V>(term: Vec<(Term, Term)>, visitor: V) -> Result<V::Value>
+where
+    V: Visitor<'de>,
+{
+    let mut deserializer = MapDeserializer::new(term);
+    let value = visitor.visit_map(&mut deserializer)?;
+    Ok(value)
+}
+
+impl<'de> de::Deserializer<'de> for Deserializer {
     type Error = Error;
 
-    fn deserialize_any<V>(self, _visitor: V) -> Result<V::Value>
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        Err(Error::TypeHintsRequired)
+        match self.term {
+            Term::Atom(v) => visitor.visit_string(v.name),
+            Term::FixInteger(v) => visitor.visit_i32(v.value),
+            Term::BigInteger(_v) => unimplemented!(),
+            Term::Float(v) => visitor.visit_f64(v.value),
+            Term::Pid(_v) => unimplemented!(),
+            Term::Port(_v) => unimplemented!(),
+            Term::Reference(_v) => unimplemented!(),
+            Term::ExternalFun(_v) => unimplemented!(),
+            Term::InternalFun(_v) => unimplemented!(),
+            Term::Binary(v) => visitor.visit_byte_buf(v.bytes),
+            Term::BitBinary(_v) => unimplemented!(),
+            Term::List(v) => visit_term_seq(v.elements, visitor),
+            Term::ImproperList(_v) => unimplemented!(),
+            Term::Tuple(v) => visit_term_seq(v.elements, visitor),
+            Term::Map(v) => visit_term_map(v.entries, visitor),
+        }
     }
 
     fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value>
@@ -144,16 +121,11 @@ impl<'de, 'a: 'de> de::Deserializer<'de> for Deserializer<'a> {
         V: Visitor<'de>,
     {
         match self.term {
-            Term::Atom(b) => {
-                if b.name == "true" {
-                    visitor.visit_bool(true)
-                } else if b.name == "false" {
-                    visitor.visit_bool(false)
-                } else {
-                    Err(Error::InvalidBoolean)
-                }
-            }
-
+            Term::Atom(b) => match b.name.as_ref() {
+                "true" => visitor.visit_bool(true),
+                "false" => visitor.visit_bool(false),
+                _ => Err(Error::InvalidBoolean),
+            },
             _ => Err(Error::ExpectedBoolean),
         }
     }
@@ -162,115 +134,115 @@ impl<'de, 'a: 'de> de::Deserializer<'de> for Deserializer<'a> {
     where
         V: Visitor<'de>,
     {
-        visitor.visit_i8(self.parse_integer()?)
+        self.deserialize_integer(visitor)
     }
 
     fn deserialize_i16<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        visitor.visit_i16(self.parse_integer()?)
+        self.deserialize_integer(visitor)
     }
 
     fn deserialize_i32<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        visitor.visit_i32(self.parse_integer()?)
+        self.deserialize_integer(visitor)
     }
 
     fn deserialize_i64<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        visitor.visit_i64(self.parse_integer()?)
+        self.deserialize_integer(visitor)
     }
 
     fn deserialize_u8<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        visitor.visit_u8(self.parse_integer()?)
+        self.deserialize_integer(visitor)
     }
 
     fn deserialize_u16<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        visitor.visit_u16(self.parse_integer()?)
+        self.deserialize_integer(visitor)
     }
 
     fn deserialize_u32<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        visitor.visit_u32(self.parse_integer()?)
+        self.deserialize_integer(visitor)
     }
 
     fn deserialize_u64<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        visitor.visit_u64(self.parse_integer()?)
+        self.deserialize_integer(visitor)
     }
 
     fn deserialize_f32<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        visitor.visit_f32(self.parse_float()?)
+        self.deserialize_f64(visitor)
     }
 
     fn deserialize_f64<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        visitor.visit_f64(self.parse_float()?)
+        match self.term {
+            Term::Float(v) => visitor.visit_f64(v.value),
+            _ => Err(Error::ExpectedFloat),
+        }
     }
 
     fn deserialize_char<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        match self.parse_string() {
-            Err(Error::ExpectedBinary) => Err(Error::ExpectedChar),
-            Err(other) => Err(other),
-            Ok(string) => {
-                if string.len() == 1 {
-                    visitor.visit_char(string.chars().next().unwrap())
-                } else {
-                    Err(Error::ExpectedChar)
-                }
-            }
-        }
+        self.deserialize_string(visitor)
     }
 
     fn deserialize_str<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        visitor.visit_string(self.parse_string()?)
+        self.deserialize_string(visitor)
     }
 
     fn deserialize_string<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        self.deserialize_str(visitor)
+        match self.term {
+            Term::Atom(v) => visitor.visit_string(v.name),
+            Term::Binary(v) => visitor.visit_byte_buf(v.bytes),
+            _ => Err(Error::ExpectedBinary),
+        }
     }
 
     fn deserialize_bytes<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        visitor.visit_bytes(self.parse_binary()?)
+        self.deserialize_byte_buf(visitor)
     }
 
     fn deserialize_byte_buf<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        visitor.visit_bytes(self.parse_binary()?)
+        match self.term {
+            Term::Binary(v) => visitor.visit_byte_buf(v.bytes),
+            _ => Err(Error::ExpectedBinary),
+        }
     }
 
     fn deserialize_option<V>(self, visitor: V) -> Result<V::Value>
@@ -278,13 +250,7 @@ impl<'de, 'a: 'de> de::Deserializer<'de> for Deserializer<'a> {
         V: Visitor<'de>,
     {
         match self.term {
-            Term::Atom(atom) => {
-                if atom.name == "nil" {
-                    visitor.visit_none()
-                } else {
-                    visitor.visit_some(self)
-                }
-            }
+            Term::Atom(v) if &v.name == "nil" => visitor.visit_none(),
             _ => visitor.visit_some(self),
         }
     }
@@ -294,13 +260,7 @@ impl<'de, 'a: 'de> de::Deserializer<'de> for Deserializer<'a> {
         V: Visitor<'de>,
     {
         match self.term {
-            Term::Atom(atom) => {
-                if atom.name == "nil" {
-                    visitor.visit_unit()
-                } else {
-                    Err(Error::ExpectedNil)
-                }
-            }
+            Term::Atom(v) if &v.name == "nil" => visitor.visit_unit(),
             _ => Err(Error::ExpectedNil),
         }
     }
@@ -327,11 +287,7 @@ impl<'de, 'a: 'de> de::Deserializer<'de> for Deserializer<'a> {
         V: Visitor<'de>,
     {
         match self.term {
-            Term::List(list) => {
-                let seq_deserializer = ListDeserializer::new(list.elements.iter());
-                visitor.visit_seq(seq_deserializer)
-                // TODO: Figure out how to call end here.
-            }
+            Term::List(v) => visit_term_seq(v.elements, visitor),
             other => {
                 eprintln!("{}", other);
                 Err(Error::ExpectedList)
@@ -344,13 +300,11 @@ impl<'de, 'a: 'de> de::Deserializer<'de> for Deserializer<'a> {
         V: Visitor<'de>,
     {
         match self.term {
-            Term::Tuple(tuple) => {
-                if tuple.elements.len() != len {
+            Term::Tuple(v) => {
+                if v.elements.len() != len {
                     return Err(Error::WrongTupleLength);
                 }
-                let seq_deserializer = ListDeserializer::new(tuple.elements.iter());
-                visitor.visit_seq(seq_deserializer)
-                // TODO: Figure out how to call end here.
+                visit_term_seq(v.elements, visitor)
             }
             _ => Err(Error::ExpectedTuple),
         }
@@ -374,15 +328,7 @@ impl<'de, 'a: 'de> de::Deserializer<'de> for Deserializer<'a> {
         V: Visitor<'de>,
     {
         match self.term {
-            Term::Map(map) => {
-                let mut map_deserializer = MapDeserializer::new(map.entries.iter());
-                visitor.visit_map(&mut map_deserializer).and_then(|result| {
-                    match map_deserializer.end() {
-                        Ok(()) => Ok(result),
-                        Err(e) => Err(e),
-                    }
-                })
-            }
+            Term::Map(v) => visit_term_map(v.entries, visitor),
             _ => Err(Error::ExpectedMap),
         }
     }
@@ -397,15 +343,8 @@ impl<'de, 'a: 'de> de::Deserializer<'de> for Deserializer<'a> {
         V: Visitor<'de>,
     {
         match self.term {
-            Term::Map(map) => {
-                let mut map_deserializer = MapDeserializer::new(map.entries.iter());
-                visitor.visit_map(&mut map_deserializer).and_then(|result| {
-                    match map_deserializer.end() {
-                        Ok(()) => Ok(result),
-                        Err(e) => Err(e),
-                    }
-                })
-            }
+            Term::List(v) => visit_term_seq(v.elements, visitor),
+            Term::Map(v) => visit_term_map(v.entries, visitor),
             _ => Err(Error::ExpectedMap),
         }
     }
@@ -419,19 +358,34 @@ impl<'de, 'a: 'de> de::Deserializer<'de> for Deserializer<'a> {
     where
         V: Visitor<'de>,
     {
-        match self.term {
-            Term::Atom(atom) => {
-                // We have a unit variant.
-                visitor.visit_enum(atom.name.to_camel_case().into_deserializer())
-            }
-            Term::Tuple(tuple) => match tuple.elements.as_slice() {
-                [variant_term, value_term] => {
-                    visitor.visit_enum(EnumDeserializer::new(&variant_term, &value_term))
+        let (variant, value) = match self.term {
+            Term::Map(value) => {
+                let mut iter = value.entries.into_iter();
+                let (variant, value) = match iter.next() {
+                    Some(v) => v,
+                    None => {
+                        return Err(de::Error::invalid_value(
+                            de::Unexpected::Map,
+                            &"map with a single key",
+                        ));
+                    }
+                };
+                // enums are encoded in json as maps with a single key:value pair
+                if iter.next().is_some() {
+                    return Err(de::Error::invalid_value(
+                        de::Unexpected::Map,
+                        &"map with a single key",
+                    ));
                 }
-                _ => Err(Error::MisSizedVariantTuple),
-            },
-            _ => Err(Error::ExpectedAtomOrTuple),
-        }
+                (variant, Some(value))
+            }
+            s @ Term::Atom(_) => (s, None),
+            _ => {
+                return Err(Error::ExpectedAtomOrTuple);
+            }
+        };
+
+        visitor.visit_enum(EnumDeserializer::new(variant, value))
     }
 
     fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value>
@@ -453,236 +407,203 @@ impl<'de, 'a: 'de> de::Deserializer<'de> for Deserializer<'a> {
     }
 }
 
-struct ListDeserializer<I>
-where
-    I: Iterator,
-{
-    iter: iter::Fuse<I>,
+struct SeqDeserializer {
+    iter: <Vec<Term> as IntoIterator>::IntoIter,
 }
 
-impl<I> ListDeserializer<I>
-where
-    I: Iterator,
-{
-    fn new(iter: I) -> Self {
-        ListDeserializer { iter: iter.fuse() }
+impl SeqDeserializer {
+    fn new(vec: Vec<Term>) -> Self {
+        SeqDeserializer {
+            iter: vec.into_iter(),
+        }
     }
 }
 
-impl<'de, 'a: 'de, I> SeqAccess<'de> for ListDeserializer<I>
-where
-    I: Iterator<Item = &'a Term>,
-{
+impl<'de> de::Deserializer<'de> for SeqDeserializer {
     type Error = Error;
 
-    fn next_element_seed<V>(&mut self, seed: V) -> Result<Option<V::Value>>
+    #[inline]
+    fn deserialize_any<V>(mut self, visitor: V) -> Result<V::Value>
     where
-        V: de::DeserializeSeed<'de>,
+        V: de::Visitor<'de>,
     {
-        match self.iter.next() {
-            Some(term) => seed.deserialize(Deserializer::from_term(term)).map(Some),
-            None => Ok(None),
-        }
-    }
-}
-
-// TODO: Look at https://github.com/flavray/avro-rs/blob/master/src/de.rs#L50-L53
-// and figure out if we can use it's ideas to simplify all this lifetime shit.
-
-struct MapDeserializer<'de, I, T>
-where
-    I: Iterator<Item = T>,
-    T: Pair<'de> + 'de,
-    First<'de, I::Item>: 'de,
-    Second<'de, I::Item>: 'de,
-{
-    items: iter::Fuse<I>,
-    current_value: Option<&'de T::Second>,
-}
-
-impl<'de, I, T> MapDeserializer<'de, I, T>
-where
-    I: Iterator<Item = T>,
-    T: Pair<'de>,
-{
-    fn new(iter: I) -> Self {
-        MapDeserializer {
-            items: iter.fuse(),
-            current_value: None,
-        }
-    }
-
-    fn end(self) -> Result<()> {
-        if self.items.count() == 0 {
-            Ok(())
+        let len = self.iter.len();
+        if len == 0 {
+            visitor.visit_unit()
         } else {
-            Err(Error::TooManyItems)
-        }
-    }
-}
-
-impl<'a, 'de: 'a, I, T> MapAccess<'de> for &'a mut MapDeserializer<'de, I, T>
-where
-    I: Iterator<Item = T>,
-    T: Pair<'de>,
-    First<'de, I::Item>: IntoEetfDeserializer,
-    Second<'de, I::Item>: IntoEetfDeserializer,
-{
-    type Error = Error;
-
-    fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>>
-    where
-        K: DeserializeSeed<'de>,
-    {
-        if self.current_value.is_some() {
-            panic!("MapDeserializer.next_key_seed was called twice in a row")
-        }
-
-        match self.items.next() {
-            Some(pair) => {
-                let (key, val) = pair.split();
-                self.current_value = Some(val);
-
-                seed.deserialize(key.into_deserializer()).map(Some)
+            let ret = visitor.visit_seq(&mut self)?;
+            let remaining = self.iter.len();
+            if remaining == 0 {
+                Ok(ret)
+            } else {
+                Err(de::Error::invalid_length(len, &"fewer elements in array"))
             }
-            None => Ok(None),
-        }
-    }
-
-    fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value>
-    where
-        V: DeserializeSeed<'de>,
-    {
-        if let Some(value) = self.current_value {
-            self.current_value = None;
-            seed.deserialize(value.into_deserializer())
-        } else {
-            panic!("MapDeserializer.next_value_seed was called before next_key_seed")
-        }
-    }
-}
-
-struct EnumDeserializer<'de> {
-    variant: &'de Term,
-    term: &'de Term,
-}
-
-impl<'de> EnumDeserializer<'de> {
-    fn new(variant: &'de Term, term: &'de Term) -> Self {
-        EnumDeserializer { variant, term }
-    }
-}
-
-// `EnumAccess` is provided to the `Visitor` to give it the ability to determine
-// which variant of the enum is supposed to be deserialized.
-//
-// Note that all enum deserialization methods in Serde refer exclusively to the
-// "externally tagged" enum representation.
-impl<'de> EnumAccess<'de> for EnumDeserializer<'de> {
-    type Error = Error;
-    type Variant = Self;
-
-    fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self::Variant)>
-    where
-        V: DeserializeSeed<'de>,
-    {
-        let val = seed.deserialize(VariantNameDeserializer::from_term(self.variant))?;
-        Ok((val, self))
-    }
-}
-
-// `VariantAccess` is provided to the `Visitor` to give it the ability to see
-// the content of the single variant that it decided to deserialize.
-impl<'de> VariantAccess<'de> for EnumDeserializer<'de> {
-    type Error = Error;
-
-    // If the `Visitor` expected this variant to be a unit variant, the input
-    // should have been the plain string case handled in `deserialize_enum`.
-    fn unit_variant(self) -> Result<()> {
-        Err(Error::ExpectedAtom)
-    }
-
-    // Newtype variants are represented in JSON as `{ NAME: VALUE }` so
-    // deserialize the value here.
-    fn newtype_variant_seed<T>(self, seed: T) -> Result<T::Value>
-    where
-        T: DeserializeSeed<'de>,
-    {
-        seed.deserialize(Deserializer::from_term(self.term))
-    }
-
-    // Tuple variants are represented in JSON as `{ NAME: [DATA...] }` so
-    // deserialize the sequence of data here.
-    fn tuple_variant<V>(self, len: usize, visitor: V) -> Result<V::Value>
-    where
-        V: Visitor<'de>,
-    {
-        let deserializer = Deserializer::from_term(self.term);
-        de::Deserializer::deserialize_tuple(deserializer, len, visitor)
-    }
-
-    // Struct variants are represented in JSON as `{ NAME: { K: V, ... } }` so
-    // deserialize the inner map here.
-    fn struct_variant<V>(self, _fields: &'static [&'static str], visitor: V) -> Result<V::Value>
-    where
-        V: Visitor<'de>,
-    {
-        let deserializer = Deserializer::from_term(self.term);
-        de::Deserializer::deserialize_map(deserializer, visitor)
-    }
-}
-
-struct VariantNameDeserializer<'a> {
-    term: &'a Term,
-}
-
-impl<'a> VariantNameDeserializer<'a> {
-    pub fn from_term(term: &'a Term) -> Self {
-        VariantNameDeserializer { term }
-    }
-}
-
-impl<'de, 'a: 'de> de::Deserializer<'de> for VariantNameDeserializer<'a> {
-    type Error = Error;
-
-    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value>
-    where
-        V: Visitor<'de>,
-    {
-        match self.term {
-            Term::Atom(atom) => visitor.visit_string(atom.name.to_camel_case()),
-            _ => Err(Error::ExpectedAtom),
         }
     }
 
     forward_to_deserialize_any! {
         bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
-            bytes byte_buf option unit unit_struct newtype_struct seq tuple
-            tuple_struct map struct enum identifier ignored_any
+        bytes byte_buf option unit unit_struct newtype_struct seq tuple
+        tuple_struct map struct enum identifier ignored_any
     }
 }
 
-mod private {
-    // Some code I stole from serde.
+impl<'de> de::SeqAccess<'de> for SeqDeserializer {
+    type Error = Error;
 
-    /// Avoid having to restate the generic types on `MapDeserializer`. The
-    /// `Iterator::Item` contains enough information to figure out K and V.
-    pub trait Pair<'a> {
-        type First;
-        type Second;
-        fn split(self) -> &'a (Self::First, Self::Second);
-    }
-
-    impl<'a, A, B> Pair<'a> for &'a (A, B) {
-        type First = A;
-        type Second = B;
-        fn split(self) -> &'a (A, B) {
-            self
+    fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>>
+    where
+        T: de::DeserializeSeed<'de>,
+    {
+        match self.iter.next() {
+            Some(value) => seed.deserialize(Deserializer::new(value)).map(Some),
+            None => Ok(None),
         }
     }
 
-    pub type First<'a, T> = <T as Pair<'a>>::First;
-    pub type Second<'a, T> = <T as Pair<'a>>::Second;
+    fn size_hint(&self) -> Option<usize> {
+        size_hint::from_bounds(&self.iter)
+    }
+}
+
+struct MapDeserializer {
+    iter: <Vec<(Term, Term)> as IntoIterator>::IntoIter,
+    value: Option<Term>,
+}
+
+impl MapDeserializer {
+    fn new(map: Vec<(Term, Term)>) -> Self {
+        MapDeserializer {
+            iter: map.into_iter(),
+            value: None,
+        }
+    }
+}
+
+impl<'de> de::MapAccess<'de> for MapDeserializer {
+    type Error = Error;
+
+    fn next_key_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>>
+    where
+        T: de::DeserializeSeed<'de>,
+    {
+        match self.iter.next() {
+            Some((key, value)) => {
+                self.value = Some(value);
+                seed.deserialize(Deserializer::new(key)).map(Some)
+            }
+            None => Ok(None),
+        }
+    }
+
+    fn next_value_seed<T>(&mut self, seed: T) -> Result<T::Value>
+    where
+        T: de::DeserializeSeed<'de>,
+    {
+        match self.value.take() {
+            Some(value) => seed.deserialize(Deserializer::new(value)),
+            None => Err(de::Error::custom("value is missing")),
+        }
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        size_hint::from_bounds(&self.iter)
+    }
+}
+
+impl<'de> de::Deserializer<'de> for MapDeserializer {
+    type Error = Error;
+
+    #[inline]
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: de::Visitor<'de>,
+    {
+        visitor.visit_map(self)
+    }
+
+    forward_to_deserialize_any! {
+        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
+        bytes byte_buf option unit unit_struct newtype_struct seq tuple
+        tuple_struct map struct enum identifier ignored_any
+    }
+}
+
+pub struct EnumDeserializer {
+    variant: Term,
+    value: Option<Term>,
+}
+
+impl EnumDeserializer {
+    pub fn new(variant: Term, value: Option<Term>) -> EnumDeserializer {
+        EnumDeserializer { variant, value }
+    }
+}
+
+impl<'de> de::EnumAccess<'de> for EnumDeserializer {
+    type Error = Error;
+    type Variant = VariantDeserializer;
+
+    fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self::Variant)>
+    where
+        V: de::DeserializeSeed<'de>,
+    {
+        let visitor = VariantDeserializer { value: self.value };
+        seed.deserialize(Deserializer::new(self.variant))
+            .map(|v| (v, visitor))
+    }
+}
+
+pub struct VariantDeserializer {
+    value: Option<Term>,
+}
+
+impl<'de> de::VariantAccess<'de> for VariantDeserializer {
+    type Error = Error;
+
+    fn unit_variant(self) -> Result<()> {
+        match self.value {
+            Some(value) => de::Deserialize::deserialize(Deserializer::new(value)),
+            None => Ok(()),
+        }
+    }
+
+    fn newtype_variant_seed<T>(self, seed: T) -> Result<T::Value>
+    where
+        T: de::DeserializeSeed<'de>,
+    {
+        match self.value {
+            Some(value) => seed.deserialize(Deserializer::new(value)),
+            None => Err(Error::ExpectedTuple),
+        }
+    }
+
+    fn tuple_variant<V>(self, _len: usize, visitor: V) -> Result<V::Value>
+    where
+        V: de::Visitor<'de>,
+    {
+        match self.value {
+            Some(Term::Tuple(v)) => {
+                de::Deserializer::deserialize_any(SeqDeserializer::new(v.elements), visitor)
+            }
+            _ => Err(Error::ExpectedTuple),
+        }
+    }
+
+    fn struct_variant<V>(self, _fields: &'static [&'static str], visitor: V) -> Result<V::Value>
+    where
+        V: de::Visitor<'de>,
+    {
+        match self.value {
+            Some(Term::Map(v)) => {
+                de::Deserializer::deserialize_any(MapDeserializer::new(v.entries), visitor)
+            }
+            Some(Term::List(v)) => {
+                de::Deserializer::deserialize_any(SeqDeserializer::new(v.elements), visitor)
+            }
+            _ => Err(Error::ExpectedMap),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -690,6 +611,7 @@ mod tests {
     use super::*;
 
     use eetf::{self, Term};
+    use std::convert::TryFrom;
 
     // Helper function for tests. Runs things through our serializer then
     // decodes and returns.
@@ -701,6 +623,31 @@ mod tests {
         Term::encode(&input, &mut cursor).expect("encode failed");
 
         from_bytes(&cursor.into_inner()).expect("deserialize failed")
+    }
+
+    #[test]
+    fn test_buffered_adjacently_tagged() {
+        #[derive(Serialize, Deserialize, Debug)]
+        #[serde(tag = "type", content = "data")]
+        enum E {
+            Float(f32),
+        }
+
+        let result: E = deserialize(Term::Map(eetf::Map::from(vec![
+            // Content must come first to trigger serde's buffering
+            (
+                Term::Atom(eetf::Atom::from("data")),
+                Term::Float(eetf::Float::try_from(159.1).unwrap()),
+            ),
+            (
+                Term::Atom(eetf::Atom::from("type")),
+                Term::Atom(eetf::Atom::from("Float")),
+            ),
+        ])));
+
+        match result {
+            E::Float(f) => assert_eq!(f, 159.1),
+        }
     }
 
     #[test]
@@ -784,6 +731,7 @@ mod tests {
     #[test]
     fn test_unit_variant() {
         #[derive(Deserialize, Debug, PartialEq)]
+        #[serde(rename_all = "snake_case")]
         enum E {
             AnOption,
             AnotherOption,
@@ -799,14 +747,15 @@ mod tests {
         // Not 100% sure if this is a tuple variant or a newtype variant.
         // But whatever I guess?
         #[derive(Deserialize, Debug, PartialEq)]
+        #[serde(rename_all = "snake_case")]
         enum ErlResult {
             Ok(String),
         };
 
-        let result: ErlResult = deserialize(Term::Tuple(eetf::Tuple::from(vec![
+        let result: ErlResult = deserialize(Term::Map(eetf::Map::from(vec![(
             Term::Atom(eetf::Atom::from("ok")),
             Term::Binary(eetf::Binary::from("test".as_bytes())),
-        ])));
+        )])));
 
         assert_eq!(result, ErlResult::Ok("test".to_string()));
     }
@@ -816,17 +765,18 @@ mod tests {
         // Not 100% sure if this is a tuple variant or a newtype variant.
         // But whatever I guess?
         #[derive(Deserialize, Debug, PartialEq)]
+        #[serde(rename_all = "snake_case")]
         enum Testing {
             Ok(u8, u8),
         };
 
-        let result: Testing = deserialize(Term::Tuple(eetf::Tuple::from(vec![
+        let result: Testing = deserialize(Term::Map(eetf::Map::from(vec![(
             Term::Atom(eetf::Atom::from("ok")),
             Term::Tuple(eetf::Tuple::from(vec![
                 Term::FixInteger(eetf::FixInteger::from(1)),
                 Term::FixInteger(eetf::FixInteger::from(2)),
             ])),
-        ])));
+        )])));
 
         assert_eq!(result, Testing::Ok(1, 2));
     }


### PR DESCRIPTION
These changes were a result of the failing test bellow.

```rust
    #[test]
    fn test_buffered_adjacently_tagged() {
        #[derive(Serialize, Deserialize, Debug)]
        #[serde(tag = "type", content = "data")]
        enum E {
            Float(f32),
        }

        let result: E = deserialize(Term::Map(eetf::Map::from(vec![
            // Content must come first to trigger serde's buffering
            (
                Term::Atom(eetf::Atom::from("data")),
                Term::Float(eetf::Float::try_from(159.1).unwrap()),
            ),
            (
                Term::Atom(eetf::Atom::from("type")),
                Term::Atom(eetf::Atom::from("Float")),
            ),
        ])));

        match result {
            E::Float(f) => assert_eq!(f, 159.1),
        }
    }
```

* Fixes an issue when deserializing an adjacently tagged enum that
  results in "buffering".
* Term is now passed by value instead of reference. This simplifies code
  complexity. There is also no implicit copying since Term does not
  derive the Copy trait.
* Variant tests have been updated to use Map instead of Tuple

Deserialization changes were derived from `serde::private::de::Content`
and `serde_json::value::de` as examples.